### PR TITLE
Improve exception handling in read_tiffs

### DIFF
--- a/flexdata/io.py
+++ b/flexdata/io.py
@@ -264,7 +264,7 @@ def read_tiffs(path, name, skip = 1, sample = 1, x_roi = [], y_roi = [], dtype =
             
             success[k] = 1
         
-        except:
+        except Exception:
             
             success[k] = 0
             


### PR DESCRIPTION
This change prevents flexdata from catching all exceptions while
reading tiffs. This change makes it possible to stop reading tiffs by
pressing CTRL-C. SIGINT was caught in the exception handler before.