### PR TITLE
Update toml / geometry format

### DIFF
--- a/examples/ex2_astra_reconst.py
+++ b/examples/ex2_astra_reconst.py
@@ -9,7 +9,7 @@ You can also install flaxTomo to be able to develope advanced reconstruction scr
 
 from flexdata import data
 from flexdata import display
-from flexdata import correction 
+from flexdata import correct
 
 import numpy
 import astra
@@ -36,7 +36,7 @@ geom = data.read_flexraylog(path, sample=binning)
 data.write_toml('scan_geometry.toml', overwrite=True, exist_ok=True)
 
 # Profiel correctie (rode streepje)    
-geom = correction.correct(geom, profile='cwi-flexray-2019-06-01', logging=False/True)
+geom = correct.correct(geom, profile='cwi-flexray-2019-05-24', do_print_changes=True)
 # Logging info:
 # INFO - Correct det_tan += 24 
 # INFO - Correct src_ort -= 7

--- a/examples/ex2_astra_reconst.py
+++ b/examples/ex2_astra_reconst.py
@@ -13,6 +13,7 @@ from flexdata import correct
 
 import numpy
 import astra
+from pathlib import Path
 
 #%% Read data:
     
@@ -36,13 +37,13 @@ geom = data.read_flexraylog(path, sample=binning)
 data.write_toml('scan_geometry.toml', overwrite=True, exist_ok=True)
 
 # Profiel correctie (rode streepje)    
-geom = correct.correct(geom, profile='cwi-flexray-2019-05-24', do_print_changes=True)
-# Logging info:
-# INFO - Correct det_tan += 24 
-# INFO - Correct src_ort -= 7
+geom = correct.correct(geom,
+                       profile='cwi-flexray-2019-05-24',
+                       do_print_changes=True)
 geom['det_ort'] -= 7
 geom.log("Corrected det_ort by -7 because reasons.")
-geom = data.calculate_volume(geom)
+# TODO: Implement geom.log()
+geom = correct.correct_vol_center(geom)
 # Logging info:
 # INFO - Volume center: (x, x, x) with size (y, y, y)
 
@@ -87,8 +88,11 @@ display.slice(vol, dim = 0, bounds = [0, 0.04], title = 'Projection', cmap = 'ma
 ###############################################################################
 #                                 This is new                                 #
 ###############################################################################
+
+# TODO: Create output directory
 data.write_stack('./output_dir/', vol)
 # Note: store geometry, with comment appended "corrected with profile 'cwi-flexray-2019-06-01'"
+# TODO: Implement storing of comments/changelog.
 data.write_toml('./output_dir/reconstruction_geometry.toml',
                 overwrite=True,
                 exist_ok=True

--- a/examples/ex2_astra_reconst.py
+++ b/examples/ex2_astra_reconst.py
@@ -34,7 +34,7 @@ data.write_toml('scan_geometry.toml')
 
 # Apply profile correction
 geom = correct.correct(geom,
-                       profile='cwi-flexray-2019-05-24',
+                       profile='cwi-flexray-2019-04-24',
                        do_print_changes=True)
 geom['det_ort'] -= 7
 geom.log("Corrected det_ort by -7 because reasons.")

--- a/flexdata/__init__.py
+++ b/flexdata/__init__.py
@@ -1,5 +1,6 @@
 from . import data
 from . import geometry
 from . import display
+from . import correct
 
 __version__ = "1.0.0"

--- a/flexdata/__init__.py
+++ b/flexdata/__init__.py
@@ -4,3 +4,8 @@ from . import display
 from . import correct
 
 __version__ = "1.0.0"
+
+# We prefer info log messages to be written to console output.
+# This can always be disabled by the user.
+import logging
+logging.basicConfig(level=logging.INFO)

--- a/flexdata/correct.py
+++ b/flexdata/correct.py
@@ -5,7 +5,7 @@ import logging
 #                             Correction profiles                             #
 ###############################################################################
 profiles = {
-    'cwi-flexray-2019-05-24': {
+    'cwi-flexray-2019-04-24': {
         'description': """
 This profile was last updated by Alex Kostenko on 24 April 2019.
 

--- a/flexdata/correct.py
+++ b/flexdata/correct.py
@@ -49,7 +49,9 @@ def correct(geometry, *, profile=None, do_print_changes=True):
     profile = profiles.get(profile)
     if profile is None:
         raise ValueError(
-            "Correction profile was not correctly specified. Choose one of: \n{profile_names}")
+            f"Correction profile was not correctly specified. Choose one of:\n"
+            f"{profile_names}"
+        )
 
     for k, v in profile.items():
         # Skip description, it is purely to describe correction profiles.

--- a/flexdata/correct.py
+++ b/flexdata/correct.py
@@ -1,0 +1,111 @@
+import logging
+
+
+###############################################################################
+#                             Correction profiles                             #
+###############################################################################
+profiles = {
+    'cwi-flexray-2019-05-24': {
+        'description': """
+This profile was last updated by Alex Kostenko on 24 April 2019.
+
+It was concurrently updated with the documentation and some other changes in the flexdata codebase.
+See:
+https://github.com/cicwi/flexDATA/commit/8859bc8073880efcb32cc57b152ef23746993ec1#diff-08f83b989c80a05906f380a66964d8d3L393
+""",
+        'det_tan': 24,
+        'src_ort': -7,
+        'axs_tan': -0.5,
+    }
+}
+
+###############################################################################
+#                             Correction functions                            #
+###############################################################################
+
+
+def print_profiles():
+    print("Profiles")
+    for k, profile in profiles.items():
+        print(f" - {k}")
+        description = profile.get('description')
+        if description is not None:
+            for l in description.split('\n'):
+                print(f"   {l}")
+
+
+def correct(geometry, *, profile=None, do_print_changes=True):
+    """Apply a correction profile to projection geometry.
+
+
+    :param geometry:
+    :param profile:
+    :returns:
+    :rtype:
+
+    """
+    profile_names = "\n".join(profiles.keys())
+
+    profile = profiles.get(profile)
+    if profile is None:
+        raise ValueError(
+            "Correction profile was not correctly specified. Choose one of: \n{profile_names}")
+
+    for k, v in profile.items():
+        # Skip description, it is purely to describe correction profiles.
+        if k == 'description':
+            continue
+
+        prev = geometry.get(k)
+        if do_print_changes:
+            logging.info(f"For {k}: adjusting {prev} by {v}.")
+        geometry[k] += v
+
+    # TODO: Add line of logging to geometry to indicate that this
+    # profile correction has taken place.
+
+    return geometry
+
+
+def correct_roi(geometry):
+    """Set the detector ort and tan to be in line with the detector ROI settings
+
+    This function is flexray-specific.
+
+    :param geometry:
+    :returns:
+    :rtype:
+
+    """
+    # Fix roi:
+    roi = geometry.description['roi']
+    # XXX: Why do we hardcode 971 and 767? Does this also work when
+    # the geometry has already been binned or hardware binning has
+    # been used?
+    centre = [(roi[0] + roi[2]) // 2 - 971, (roi[1] + roi[3]) // 2 - 767]
+
+    # Not sure the binning should be taken into account...
+    geometry.parameters['det_ort'] -= centre[1] * \
+        geometry.parameters['det_pixel']
+    geometry.parameters['det_tan'] -= centre[0] * \
+        geometry.parameters['det_pixel']
+
+    return geometry
+
+
+def correct_vol_center(geometry):
+    """Move the volume center to be between the source and detector center.
+
+    :param geometry:
+    :returns:
+    :rtype:
+
+    """
+
+    geom = geometry
+    geom.parameters['vol_tra'][0] = (geom.parameters['det_ort'] * geom.src2obj +
+                                     geom.parameters['src_ort'] * geom.det2obj) / geom.src2det
+
+    # TODO: Print changes to volume geometry..
+
+    return geometry

--- a/flexdata/correct.py
+++ b/flexdata/correct.py
@@ -94,7 +94,7 @@ def correct_roi(geometry):
 
 
 def correct_vol_center(geometry):
-    """Move the volume center to be between the source and detector center.
+    """Move the volume center in-between the source and detector center.
 
     :param geometry:
     :returns:

--- a/flexdata/correct.py
+++ b/flexdata/correct.py
@@ -119,5 +119,7 @@ def correct_vol_center(geometry):
                                      geom.parameters['src_ort'] * geom.det2obj) / geom.src2det
 
     # TODO: Print changes to volume geometry..
+    # Logging info:
+    # INFO - Volume center: (x, x, x) with size (y, y, y)
 
     return geometry

--- a/flexdata/data.py
+++ b/flexdata/data.py
@@ -368,7 +368,26 @@ def read_image(file, sample = 1, shape = None, format = None, dtype = None):
     im = _sample_image_(im, sample)
     return im
 
-def read_flexraylog(path, sample = 1):
+def read_flexraylog(path, *args):
+   warnings.warn("""
+read_flexraylog is depecrated.
+
+This function combined too much functionality. If you want similar functionality to what
+read_flexraylog provided, use:
+>>> from flexdata import data
+>>> from flexdata import correct
+>>> geom = data.parse_flexraylog(path, sample=binning)
+>>> geom = correct.correct(geom,
+                           profile='cwi-flexray-2019-05-24',
+                           do_print_changes=True)
+>>> geom = correct.correct_vol_center(geom)
+
+
+""", DeprecationWarning, stacklevel=2)
+   raise NotImplementedError()
+
+
+def parse_flexraylog(path, sample = 1):
     """
     Read the log file of FLexRay scanner and return dictionaries with parameters of the scan.
 
@@ -441,9 +460,29 @@ def read_flexraylog(path, sample = 1):
 
     return geom
 
-def read_flexraymeta(path, sample = 1):
+
+def read_flexraymeta(*args):
+   warnings.warn("""
+read_flexraymeta is depecrated.
+
+This function combined too much functionality. If you want similar functionality to what
+read_flexraymeta provided, use:
+>>> from flexdata import data
+>>> from flexdata import correct
+>>> geom = data.parse_flexraymeta(path, sample=binning)
+>>> geom = correct.correct(geom,
+                           profile='cwi-flexray-2019-05-24',
+                           do_print_changes=True)
+>>> geom = correct.correct_vol_center(geom)
+
+
+""", DeprecationWarning, stacklevel=2)
+   raise NotImplementedError()
+
+
+def parse_flexraymeta(path, sample = 1):
     """
-    Read the metafile produced by Flexray scripting.
+    Read the metafile produced by the Flexray script generator.
 
     Args:
         path   (str): path to the files location
@@ -517,6 +556,7 @@ def read_flexraymeta(path, sample = 1):
     geom.parameters['img_pixel'] *= sample
 
     return geom
+
 
 def read_geometry(path, sample = 1):
     '''

--- a/flexdata/data.py
+++ b/flexdata/data.py
@@ -379,7 +379,7 @@ read_flexraylog provided, use:
 >>> from flexdata import correct
 >>> geom = data.parse_flexraylog(path, sample=binning)
 >>> geom = correct.correct(geom,
-                           profile='cwi-flexray-2019-05-24',
+                           profile='cwi-flexray-2019-04-24',
                            do_print_changes=True)
 >>> geom = correct.correct_vol_center(geom)
 
@@ -477,7 +477,7 @@ read_flexraymeta provided, use:
 >>> from flexdata import correct
 >>> geom = data.parse_flexraymeta(path, sample=binning)
 >>> geom = correct.correct(geom,
-                           profile='cwi-flexray-2019-05-24',
+                           profile='cwi-flexray-2019-04-24',
                            do_print_changes=True)
 >>> geom = correct.correct_vol_center(geom)
 
@@ -550,21 +550,21 @@ def parse_flexraymeta(path, sample = 1):
         records['img_pixel'] *= 4
         pixel_adjustment = 4
 
-    if pixel_adjustment != 1:
-       msg = f"Adjusted pixel size by {pixel_adjustement} due to {records['mode']}"
-       logging.info(msg)
-       geom.log(msg)
-
     # Check version
     version = records.get('FLEXTOML_VERSION')
     if version is None:
        logger.warning(f"No version for toml file. Expected {geom.FLEXTOML_VERSION}")
-    elif version != geom.FLEXTOML_VERSION:
+    elif version != geometry.FLEXTOML_VERSION:
        logger.warning(f"Version {version} found for toml file. Expected: {geom.FLEXTOML_VERSION}")
 
     # Initialize geometry:
     geom = geometry.circular()
     geom.from_dictionary(records)
+
+    if pixel_adjustment != 1:
+       msg = f"Adjusted pixel size by {pixel_adjustement} due to {records['mode']}"
+       logging.info(msg)
+       geom.log(msg)
 
     geom.parameters['det_pixel'] *= sample
     geom.parameters['img_pixel'] *= sample
@@ -596,7 +596,7 @@ def read_geometry(path, sample = 1):
     version = records.get('FLEXTOML_VERSION')
     if version is None:
        logger.warning(f"No version for toml file. Expected {geometry.FLEXTOML_VERSION}")
-    elif version != geom.FLEXTOML_VERSION:
+    elif version != geometry.FLEXTOML_VERSION:
        logger.warning(f"Version {version} found for toml file. Expected: {geometry.FLEXTOML_VERSION}")
 
     # Initialize geometry:

--- a/flexdata/data.py
+++ b/flexdata/data.py
@@ -29,8 +29,6 @@ from . import geometry       # geometry classes
 # >>>>>>>>>>>>>>>>>>>> LOGGER CLASS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 
-FLEXTOML_VERSION = '0.1.1'
-
 class logger:
    """
    A class for logging and printing messages.
@@ -505,6 +503,13 @@ def read_flexraymeta(path, sample = 1):
         records['det_pixel'] *= 4
         records['img_pixel'] *= 4
 
+    # Check version
+    version = records.get('FLEXTOML_VERSION')
+    if version is None:
+       logger.warning(f"No version for toml file. Expected {geom.FLEXTOML_VERSION}")
+    elif version != geom.FLEXTOML_VERSION:
+       logger.warning(f"Version {version} found for toml file. Expected: {geom.FLEXTOML_VERSION}")
+
     # Initialize geometry:
     geom = geometry.circular()
     geom.from_dictionary(records)
@@ -528,6 +533,13 @@ def read_geometry(path, sample = 1):
     records = read_toml(os.path.join(path, 'geometry.toml'))
     records['det_pixel'] *= sample
     records['img_pixel'] *= sample
+
+    # Check version
+    version = records.get('FLEXTOML_VERSION')
+    if version is None:
+       logger.warning(f"No version for toml file. Expected {geom.FLEXTOML_VERSION}")
+    elif version != geom.FLEXTOML_VERSION:
+       logger.warning(f"Version {version} found for toml file. Expected: {geom.FLEXTOML_VERSION}")
 
     # Initialize geometry:
     geom = geometry.circular()

--- a/flexdata/data.py
+++ b/flexdata/data.py
@@ -27,6 +27,10 @@ from scipy.io import loadmat # Reading matlab format
 from . import geometry       # geometry classes
 
 # >>>>>>>>>>>>>>>>>>>> LOGGER CLASS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+
+FLEXTOML_VERSION = '0.1.1'
+
 class logger:
    """
    A class for logging and printing messages.
@@ -1402,6 +1406,14 @@ def _parse_unit_(string):
 
     return factor
 
+profiles = {
+   'cwi-flexray-2019-06-01': {
+      'det_tan': 24,
+      'src_ort': -7,
+      'axs_tan': -0.5,
+   }
+}
+
 def _flex_motor_correct_(geom):
     '''
     Apply some motor offsets to get to a correct coordinate system.
@@ -1417,12 +1429,17 @@ def _flex_motor_correct_(geom):
 
     # roi:
     roi = geom.description['roi']
+    # XXX: Why do we hardcode 971 and 767? Does this also work when
+    # the geometry has already been binned or hardware binning has
+    # been used?
     centre = [(roi[0] + roi[2]) // 2 - 971, (roi[1] + roi[3]) // 2 - 767]
 
     # Not sure the binning should be taken into account...
     geom.parameters['det_ort'] -= centre[1] * geom.parameters['det_pixel']
     geom.parameters['det_tan'] -= centre[0] * geom.parameters['det_pixel']
 
+    # This is part of volume geometry determination.
+    # TODO: Split into separate function. Should NOT occur automatically. 
     geom.parameters['vol_tra'][0] = (geom.parameters['det_ort'] * geom.src2obj +
                    geom.parameters['src_ort'] * geom.det2obj) / geom.src2det
 

--- a/flexdata/data.py
+++ b/flexdata/data.py
@@ -536,9 +536,9 @@ def read_geometry(path, sample = 1):
     # Check version
     version = records.get('FLEXTOML_VERSION')
     if version is None:
-       logger.warning(f"No version for toml file. Expected {geom.FLEXTOML_VERSION}")
+       logger.warning(f"No version for toml file. Expected {geometry.FLEXTOML_VERSION}")
     elif version != geom.FLEXTOML_VERSION:
-       logger.warning(f"Version {version} found for toml file. Expected: {geom.FLEXTOML_VERSION}")
+       logger.warning(f"Version {version} found for toml file. Expected: {geometry.FLEXTOML_VERSION}")
 
     # Initialize geometry:
     geom = geometry.circular()

--- a/flexdata/data.py
+++ b/flexdata/data.py
@@ -23,6 +23,7 @@ import psutil         # RAM tester
 import toml           # TOML format parcer
 from tqdm import tqdm # Progress barring
 import time           # Pausing
+import logging
 from scipy.io import loadmat # Reading matlab format
 from . import geometry       # geometry classes
 from .correct import correct_roi
@@ -458,6 +459,11 @@ def parse_flexraylog(path, sample = 1):
 
     geom = correct_roi(geom)
 
+    if sample != 1:
+        msg = f"Adjusted geometry by binning by {sample}"
+        logging.info(msg)
+        geom.log(msg)
+
     return geom
 
 
@@ -533,13 +539,21 @@ def parse_flexraymeta(path, sample = 1):
     records['roi'] = roi.tolist()
 
     # Detector pixel is not changed here when binning mode is on...
+    pixel_adjustment = 1
     if (records['mode'] == 'HW2SW1High')|(records['mode'] == 'HW1SW2High'):
         records['det_pixel'] *= 2
         records['img_pixel'] *= 2
+        pixel_adjustment = 2
 
     elif (records['mode'] == 'HW2SW2High'):
         records['det_pixel'] *= 4
         records['img_pixel'] *= 4
+        pixel_adjustment = 4
+
+    if pixel_adjustment != 1:
+       msg = f"Adjusted pixel size by {pixel_adjustement} due to {records['mode']}"
+       logging.info(msg)
+       geom.log(msg)
 
     # Check version
     version = records.get('FLEXTOML_VERSION')
@@ -554,6 +568,11 @@ def parse_flexraymeta(path, sample = 1):
 
     geom.parameters['det_pixel'] *= sample
     geom.parameters['img_pixel'] *= sample
+
+    if sample != 1:
+        msg = f"Adjusted geometry by binning by {sample}"
+        logging.info(msg)
+        geom.log(msg)
 
     return geom
 

--- a/flexdata/geometry.py
+++ b/flexdata/geometry.py
@@ -12,7 +12,7 @@ volume transformations ('vol_tra', 'vol_rot'), recostruction resolution and anis
 import astra
 import numpy
 from transforms3d import euler
-
+from datetime import datetime
 
 FLEXTOML_VERSION = '0.1.0'
 
@@ -164,6 +164,20 @@ class basic():
         for key in min_set:
             if not key in self.parameters:
                 raise Exception('Geometry parameter missing after parcing: ' + key)
+
+    def log(self, message):
+        """Add a message to the geometry changelog.
+
+        This changelog will be saved with the geometry in a toml file.
+
+        :param message: A message to log (single line).
+        :returns: None
+        :rtype: NoneType
+
+        """
+        changelog = self.description.get('changelog', '')
+        changelog += f"{datetime.now():%Y-%m-%d}: {message}\n"
+        self.description['changelog'] = changelog
 
     @property
     def vol_sample(self):

--- a/flexdata/geometry.py
+++ b/flexdata/geometry.py
@@ -10,9 +10,12 @@ volume transformations ('vol_tra', 'vol_rot'), recostruction resolution and anis
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>> Imports >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 import astra
-
 import numpy
 from transforms3d import euler
+
+
+FLEXTOML_VERSION = '0.1.0'
+
 
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>> Classes >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 class basic():
@@ -51,7 +54,9 @@ class basic():
                            'vol_sample':[1,1,1]
                            }
 
-        self.description = {}
+        self.description = {
+            'flextoml_version' : FLEXTOML_VERSION,
+        }
 
     def __str__(self):
         '''

--- a/flexdata/geometry.py
+++ b/flexdata/geometry.py
@@ -55,7 +55,7 @@ class basic():
                            }
 
         self.description = {
-            'flextoml_version' : FLEXTOML_VERSION,
+            'flextoml_version': FLEXTOML_VERSION,
         }
 
     def __str__(self):


### PR DESCRIPTION
This pull requests

Adds
- A version string to the toml format / `geometry.description' dictionary
- Geometry correction functions in `flexdata.correct'
- A changelog to the toml format / `geometry.description' dictionary
- A `geom.log()' method to write to this changelog
- Many explicit logging functions
- parse_*_log functions to parse and *only parse* log files from the flexray and metadata generated by the script generator. 

Removes:
- read_*_log functions have been deprecated