### PR TITLE
Fix ROI correction in _flex_motor_correct_

### DIFF
--- a/flexdata/data.py
+++ b/flexdata/data.py
@@ -1417,9 +1417,10 @@ def _flex_motor_correct_(geom):
     roi = geom.description['roi']
     centre = [(roi[0] + roi[2]) // 2 - 971, (roi[1] + roi[3]) // 2 - 767]
 
-    # Not sure the binning should be taken into account...
-    geom.parameters['det_ort'] -= centre[1] * geom.parameters['det_pixel']
-    geom.parameters['det_tan'] -= centre[0] * geom.parameters['det_pixel']
+    # ROI is written for a pixel in 1x1 binning, so 75 um should be used for correction
+    detector_pixel_size = 0.0748
+    geom.parameters['det_ort'] += centre[1] * detector_pixel_size
+    geom.parameters['det_tan'] += centre[0] * detector_pixel_size
 
     geom.parameters['vol_tra'][0] = (geom.parameters['det_ort'] * geom.src2obj +
                    geom.parameters['src_ort'] * geom.det2obj) / geom.src2det


### PR DESCRIPTION
ROI code was using detector pixel after binning even though numbers 971 and 767 refer to a binning of 1. Thus, the centre position is not shifted correctly.