### PR TITLE
Let read_stack directly store stack in transposed form

### DIFF
--- a/flexdata/data.py
+++ b/flexdata/data.py
@@ -1043,7 +1043,7 @@ def get_files_sorted(path, name):
     files = [os.path.join(path,x) for x in files if (name in x)]
 
     # Keys
-    keys = [int(re.findall('\d+', f)[-1]) for f in files]
+    keys = [int(re.findall('\\d+', f)[-1]) for f in files]
 
     # Sort files using keys:
     files = [f for (k, f) in sorted(zip(keys, files))]

--- a/tests/test_read_stack_transpose.py
+++ b/tests/test_read_stack_transpose.py
@@ -1,0 +1,20 @@
+from flexdata import data
+import numpy as np
+
+
+def test_read_stack_transpose():
+    path = '/ufs/ciacc/flexbox/skull/'
+    proj = data.read_stack(path, 'scan_', skip=4, sample=4, updown=False,
+                           transpose=[0, 1, 2])
+
+    proj_transpose = data.read_stack(path, 'scan_', skip=4, sample=4,
+                                     updown=False, transpose=[1, 0, 2])
+    assert np.array_equal(proj_transpose.transpose([1, 0, 2]), proj)
+
+    proj_transpose = data.read_stack(path, 'scan_', skip=4, sample=4,
+                                     updown=False, transpose=[0, 2, 1])
+    assert np.array_equal(proj_transpose.transpose([0, 2, 1]), proj)
+
+    proj_transpose = data.read_stack(path, 'scan_', skip=4, sample=4,
+                                     updown=False, transpose=[2, 1, 0])
+    assert np.array_equal(proj_transpose.transpose([2, 1, 0]), proj)


### PR DESCRIPTION
This saves a duplicate copy of the array in memory for doing the final 3D transpose (or the eventual ascontiguousarray()). For large arrays this saves a large amount of memory, and is apparently slightly faster too, when factoring in the cost of ascontiguousarray().